### PR TITLE
Fix typo in c21 calculation

### DIFF
--- a/DPS.py
+++ b/DPS.py
@@ -312,7 +312,7 @@ class DPS:
 
 
 
-        c21 = (src1E < 8) | src1F
+        c21 = (src1E << 8) | src1F
 
         c21 = getTwosComplement(c21, 16)
 


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

Description

In c21 calculation, `<` is used instead of `<<`, which results in wrong c21 value in most cases.